### PR TITLE
Submitted 2019.710.1 to Microsoft Store

### DIFF
--- a/src/MediaFileManager/MediaFileManager.Desktop/App.xaml
+++ b/src/MediaFileManager/MediaFileManager.Desktop/App.xaml
@@ -1,15 +1,7 @@
-﻿<Application x:Class="MediaFileManager.Desktop.App" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:telerik="http://schemas.telerik.com/2008/xaml/presentation" StartupUri="MainWindow.xaml">
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/System.Windows.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.Navigation.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.Docking.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.Input.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.GridView.xaml" />
-                <ResourceDictionary Source="/Telerik.Windows.Themes.Fluent;component/Themes/Telerik.Windows.Controls.FileDialogs.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Application.Resources>
+﻿<Application x:Class="MediaFileManager.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:telerik="http://schemas.telerik.com/2008/xaml/presentation"
+             StartupUri="MainWindow.xaml">
+
 </Application>

--- a/src/MediaFileManager/MediaFileManager.Desktop/App.xaml.cs
+++ b/src/MediaFileManager/MediaFileManager.Desktop/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using Telerik.Windows.Controls;
 
 namespace MediaFileManager.Desktop
 {
@@ -6,7 +7,8 @@ namespace MediaFileManager.Desktop
     {
         public App()
         {
-           this.InitializeComponent();
+            StyleManager.ApplicationTheme = new FluentTheme();
+            this.InitializeComponent();
         }
     }
 }

--- a/src/MediaFileManager/MediaFileManager.Desktop/MediaFileManager.Desktop.csproj
+++ b/src/MediaFileManager/MediaFileManager.Desktop/MediaFileManager.Desktop.csproj
@@ -55,35 +55,31 @@
       <HintPath>..\packages\taglib.2.1.0.0\lib\taglib-sharp.dll</HintPath>
     </Reference>
     <Reference Include="Telerik.Windows.Controls, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Controls.Docking, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.Docking.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.Docking.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Controls.FileDialogs, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.FileDialogs.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.FileDialogs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Controls.GridView, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.GridView.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.GridView.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Controls.Input, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.Input.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.Input.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Controls.Navigation, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Controls.Navigation.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Controls.Navigation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Telerik.Windows.Data, Version=2019.2.618.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Data.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Telerik.Windows.Themes.Fluent">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries.NoXaml\WPF45\Telerik.Windows.Themes.Fluent.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Progress\Telerik UI for WPF R2 2019\Binaries\WPF45\Telerik.Windows.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/src/MediaFileManager/PackageProject/Package.appxmanifest
+++ b/src/MediaFileManager/PackageProject/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="61469LanceLotSoftware.MediaFileManager"
     Publisher="CN=51B5A8B2-5D86-4826-BBE2-C92E963A4C02"
-    Version="2019.708.1.0" />
+    Version="2019.710.1.0" />
 
   <Properties>
     <DisplayName>Media File Manager</DisplayName>


### PR DESCRIPTION
The initial certification failed because the release-build of the package did not contain the NoXaml FluentTheme assembly. Switching to Xaml assemblies and avoiding Implcit Styling fixed the issue.